### PR TITLE
Fix regex that matches fenced code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ Default config:
 ````lua
 require("headlines").setup {
     markdown = {
-        source_pattern_start = "^```",
-        source_pattern_end = "^```$",
-        dash_pattern = "^---+$",
-        headline_pattern = "^#+",
+        source_pattern_start = "^%s*```+",
+        source_pattern_end = "^%s*```+$",
+        dash_pattern = "^%s*---+$",
+        headline_pattern = "^%s*#+",
         headline_signs = { "Headline" },
         codeblock_sign = "CodeBlock",
         dash_highlight = "Dash",

--- a/lua/headlines/init.lua
+++ b/lua/headlines/init.lua
@@ -5,8 +5,8 @@ M.sign_namespace = "headlines_sign_namespace"
 
 M.config = {
     markdown = {
-        source_pattern_start = "^```",
-        source_pattern_end = "^```$",
+        source_pattern_start = "^```+",
+        source_pattern_end = "^```+$",
         dash_pattern = "^---+$",
         headline_pattern = "^#+",
         headline_signs = { "Headline" },

--- a/lua/headlines/init.lua
+++ b/lua/headlines/init.lua
@@ -5,10 +5,10 @@ M.sign_namespace = "headlines_sign_namespace"
 
 M.config = {
     markdown = {
-        source_pattern_start = "^```+",
-        source_pattern_end = "^```+$",
-        dash_pattern = "^---+$",
-        headline_pattern = "^#+",
+        source_pattern_start = "^%s*```+",
+        source_pattern_end = "^%s*```+$",
+        dash_pattern = "^%s*---+$",
+        headline_pattern = "^%s*#+",
         headline_signs = { "Headline" },
         codeblock_sign = "CodeBlock",
         dash_highlight = "Dash",


### PR DESCRIPTION
Without this, it does not match blocks below.

`````markdown
<!-- ` x 4 or over -->
<!-- and have spaces on the head -->
   ````lua
   print'Hello World!'
   ````
`````