### PR TITLE
Fix: Correct packer installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ Use your favourite plugin manager to install.
 -- init.lua
 require("packer").startup(
     function()
-        use("lukas-reineke/headlines.nvim"),
-        config = function()
-            require("headlines").setup()
-        end
+          use {
+            'lukas-reineke/headlines.nvim',
+            config = function()
+              require('headlines').setup()
+            end,
+          }
     end
 )
 ```


### PR DESCRIPTION
The `packer` example in the README had a misplaced parenthesis/was missing brackets.