### PR TITLE
BREAKING CHANGE use ext marks instead of signs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ require("headlines").setup {
         source_pattern_end = "^```$",
         dash_pattern = "^---+$",
         headline_pattern = "^#+",
-        headline_signs = { "Headline" },
-        codeblock_sign = "CodeBlock",
+        headline_highlights = { "Headline" },
+        codeblock_highlight = "CodeBlock",
         dash_highlight = "Dash",
     },
     rmd = {
@@ -77,8 +77,8 @@ require("headlines").setup {
         source_pattern_end = "^}}}$",
         dash_pattern = "^---+$",
         headline_pattern = "^=+",
-        headline_signs = { "Headline" },
-        codeblock_sign = "CodeBlock",
+        headline_highlights = { "Headline" },
+        codeblock_highlight = "CodeBlock",
         dash_highlight = "Dash",
     },
     org = {
@@ -86,8 +86,8 @@ require("headlines").setup {
         source_pattern_end = "#%+[eE][nN][dD]_[sS][rR][cC]",
         dash_pattern = "^-----+$",
         headline_pattern = "^%*+",
-        headline_signs = { "Headline" },
-        codeblock_sign = "CodeBlock",
+        headline_highlights = { "Headline" },
+        codeblock_highlight = "CodeBlock",
         dash_highlight = "Dash",
     },
 }
@@ -121,12 +121,10 @@ vim.cmd [[highlight Headline1 guibg=#1e2718]]
 vim.cmd [[highlight Headline2 guibg=#21262d]]
 vim.cmd [[highlight CodeBlock guibg=#1c1c1c]]
 vim.cmd [[highlight Dash guibg=#D19A66 gui=bold]]
-vim.fn.sign_define("Headline1", { linehl = "Headline1" })
-vim.fn.sign_define("Headline2", { linehl = "Headline2" })
 
 require("headlines").setup {
     org = {
-        headline_signs = { "Headline1", "Headline2" },
+        headline_highlights = { "Headline1", "Headline2" },
     },
 }
 ```

--- a/doc/headlines.txt
+++ b/doc/headlines.txt
@@ -2,7 +2,7 @@
 
 
 Author: Lukas Reineke <lukas.reineke@protonmail.com>
-Version: 1.0.0
+Version: 2.0.0
 
 ==============================================================================
 CONTENTS                                                           *headlines*
@@ -75,8 +75,8 @@ Default config: >
           source_pattern_end = "^```$",
           dash_pattern = "^---+$",
           headline_pattern = "^#+",
-          headline_signs = { "Headline" },
-          codeblock_sign = "CodeBlock",
+          headline_highlights = { "Headline" },
+          codeblock_highlight = "CodeBlock",
           dash_highlight = "Dash",
       },
       rmd = {
@@ -93,8 +93,8 @@ Default config: >
           source_pattern_end = "^}}}$",
           dash_pattern = "^---+$",
           headline_pattern = "^=+",
-          headline_signs = { "Headline" },
-          codeblock_sign = "CodeBlock",
+          headline_highlights = { "Headline" },
+          codeblock_highlight = "CodeBlock",
           dash_highlight = "Dash",
       },
       org = {
@@ -102,8 +102,8 @@ Default config: >
           source_pattern_end = "#%+[eE][nN][dD]_[sS][rR][cC]",
           dash_pattern = "^-----+$",
           headline_pattern = "^%*+",
-          headline_signs = { "Headline" },
-          codeblock_sign = "CodeBlock",
+          headline_highlights = { "Headline" },
+          codeblock_highlight = "CodeBlock",
           dash_highlight = "Dash",
       },
   }
@@ -138,21 +138,15 @@ headline_pattern                                  *headlines-headline_pattern*
     The length of the match is used to determine the level of the headline.
 
 ------------------------------------------------------------------------------
-headline_signs                                      *headlines-headline_signs*
+headline_highlights                            *headlines-headline_highlights*
 
-    A list of |sign|s that are used to highlight the headline.
+    A list of |highlight| groups that are used to highlight the headline.
     The level of the headline is used as the index of the list.
 
-    To create new signs, define a highlight group, and create a new sign with
-    that highlight group.
-
-    `vim.cmd [[highlight SecondHeadline guibg=#333333]]`
-    `vim.fn.sign_define("SecondHeadline", { linehl = "SecondHeadline" })`
-
 ------------------------------------------------------------------------------
-codeblock_sign                                      *headlines-codeblock_sign*
+codeblock_highlight                            *headlines-codeblock_highlight*
 
-    Specifies the |sign| that is used to highlight code blocks.
+    Specifies the |highlight| grop that is used to highlight code blocks.
 
 ------------------------------------------------------------------------------
 dash_highlight                                      *headlines-dash_highlight*
@@ -161,6 +155,13 @@ dash_highlight                                      *headlines-dash_highlight*
 
 ==============================================================================
  4. CHANGELOG                                            *headlines-changelog*
+
+2.0.0
+  * Remove the use of signs [BREAKING CHANGE]
+  * `headline_signs` is renamed to `headline_highlights` and takes a list of
+    highlight groups instead of a list of signs.
+  * `codeblock_sign` is renamed to `codeblock_highlight` and takes a highlight
+    group instead of a sign.
 
 1.0.0
   * First release


### PR DESCRIPTION
All highlights are now done with ext marks.

The setup api has following breaking changes.

`headline_signs` is renamed to `headline_highlights` and takes a list of
highlight groups instead of a list of signs.

`codeblock_sign` is renamed to `codeblock_highlight` and takes a
highlight group instead of a sign.