### PR TITLE
fix: allow calling setup without a config table

### DIFF
--- a/lua/headlines/init.lua
+++ b/lua/headlines/init.lua
@@ -159,7 +159,8 @@ M.make_reverse_highlight = function(name)
 end
 
 M.setup = function(config)
-    M.config = vim.tbl_deep_extend("force", M.config, config or {})
+    config = config or {}
+    M.config = vim.tbl_deep_extend("force", M.config, config)
 
     -- tbl_deep_extend does not handle metatables
     for filetype, conf in pairs(config) do


### PR DESCRIPTION
The `setup` function assumed `config` was defined and iterated over it. This meant users needed to provide a configuration table. Otherwise, they would get a runtime error trying to iterate `nil`.

I believe this was a typo done in 45f6418660faaf22bc12dcae3b5b08d135ba6d4e