### PR TITLE
feat: allow highlighting only the heading marker chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ require("headlines").setup {
         fat_headlines = true,
         fat_headline_upper_string = "▃",
         fat_headline_lower_string = "🬂",
+        whole_line = true,
     },
     rmd = {
         query = vim.treesitter.parse_query(
@@ -134,6 +135,7 @@ require("headlines").setup {
         fat_headlines = true,
         fat_headline_upper_string = "▃",
         fat_headline_lower_string = "🬂",
+        whole_line = true,
     },
     norg = {
         query = vim.treesitter.parse_query(
@@ -170,6 +172,7 @@ require("headlines").setup {
         fat_headlines = true,
         fat_headline_upper_string = "▃",
         fat_headline_lower_string = "🬂",
+        whole_line = true,
     },
     org = {
         query = vim.treesitter.parse_query(
@@ -201,6 +204,7 @@ require("headlines").setup {
         fat_headlines = true,
         fat_headline_upper_string = "▃",
         fat_headline_lower_string = "🬂",
+        whole_line = true,
     },
 }
 ```

--- a/doc/headlines.txt
+++ b/doc/headlines.txt
@@ -124,6 +124,7 @@ Default config: >
           fat_headlines = true,
           fat_headline_upper_string = "▃",
           fat_headline_lower_string = "🬂",
+          whole_line = true,
       },
       rmd = {
           query = vim.treesitter.parse_query(
@@ -156,6 +157,7 @@ Default config: >
           fat_headlines = true,
           fat_headline_upper_string = "▃",
           fat_headline_lower_string = "🬂",
+          whole_line = true,
       },
       norg = {
           query = vim.treesitter.parse_query(
@@ -192,6 +194,7 @@ Default config: >
           fat_headlines = true,
           fat_headline_upper_string = "▃",
           fat_headline_lower_string = "🬂",
+          whole_line = true,
       },
       org = {
           query = vim.treesitter.parse_query(
@@ -223,6 +226,7 @@ Default config: >
           fat_headlines = true,
           fat_headline_upper_string = "▃",
           fat_headline_lower_string = "🬂",
+          whole_line = true,
       },
   }
 
@@ -304,6 +308,13 @@ quote_highlight                                      *headlines-quote_highlight*
 quote_string                                            *headlines-quote_string*
 
     Specifies the string that is used to display quotes.
+
+------------------------------------------------------------------------------
+whole_line                                                headlines-whole_line
+
+    Boolean to turn on whole line highlighting. Turn off to highlight only
+    the heading characters. This option is ignored and assumed enabled when
+    |headlines-fat_headlines| are enabled.
 
 ==============================================================================
  4. LICENSE                                                *headlines-license*

--- a/lua/headlines/init.lua
+++ b/lua/headlines/init.lua
@@ -46,6 +46,7 @@ M.config = {
         fat_headlines = true,
         fat_headline_upper_string = "▃",
         fat_headline_lower_string = "🬂",
+        whole_line = true,
     },
     rmd = {
         query = parse_query_save(
@@ -78,6 +79,7 @@ M.config = {
         fat_headlines = true,
         fat_headline_upper_string = "▃",
         fat_headline_lower_string = "🬂",
+        whole_line = true,
     },
     norg = {
         query = parse_query_save(
@@ -114,6 +116,7 @@ M.config = {
         fat_headlines = true,
         fat_headline_upper_string = "▃",
         fat_headline_lower_string = "🬂",
+        whole_line = true,
     },
     org = {
         query = parse_query_save(
@@ -145,6 +148,7 @@ M.config = {
         fat_headlines = true,
         fat_headline_upper_string = "▃",
         fat_headline_lower_string = "🬂",
+        whole_line = true,
     },
 }
 
@@ -229,13 +233,23 @@ M.refresh = function()
                 local get_text_function = use_legacy_query and q.get_node_text(node, bufnr)
                     or vim.treesitter.get_node_text(node, bufnr)
                 local level = #vim.trim(get_text_function)
-                local hl_group = c.headline_highlights[math.min(level, #c.headline_highlights)]
-                nvim_buf_set_extmark(bufnr, M.namespace, start_row, 0, {
-                    end_col = 0,
-                    end_row = start_row + 1,
-                    hl_group = hl_group,
-                    hl_eol = true,
-                })
+                level = math.min(level, #c.headline_highlights)
+                local hl_group = c.headline_highlights[level]
+                if c.whole_line and ! c.fat_headlines then
+                    nvim_buf_set_extmark(bufnr, M.namespace, start_row, 0, {
+                        end_col = 0,
+                        end_row = start_row + 1,
+                        hl_group = hl_group,
+                        hl_eol = true,
+                    })
+                else
+                    nvim_buf_set_extmark(bufnr, M.namespace, start_row, 0, {
+                        end_col = level,
+                        end_row = start_row + 0,
+                        hl_group = hl_group,
+                        hl_eol = true,
+                    })
+                end
 
                 if c.fat_headlines then
                     local reverse_hl_group = M.make_reverse_highlight(hl_group)


### PR DESCRIPTION
Allows highlighting only the characters marking the headline.

For example with the new option disabled(enabled by default to avoid breaking changes):
```md
### Heading
```

Will only highlight the 3 '#' chars.

-------------

I've made an attempt at documenting the changes.

Also this option does not /really/ make much sense with fat headlines, so it only kicks in when the new option and fat_headlines are set to false.


# Whole lines turned off (also fat headlines turned off)

new behavior

![image](https://github.com/lukas-reineke/headlines.nvim/assets/51170833/dadec670-f2e9-49b1-ac1d-37c48786b1d3)

# Whole lines turned on

existing and default behavior

![image](https://github.com/lukas-reineke/headlines.nvim/assets/51170833/64dfb38a-140e-47e6-918a-291a9455d9d4)
