### PR TITLE
Two types of Norg verbatim blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,14 @@ require("headlines").setup {
                 (weak_paragraph_delimiter) @dash
                 (strong_paragraph_delimiter) @doubledash
 
-                ((ranged_tag
+                ([(ranged_tag
                     name: (tag_name) @_name
                     (#eq? @_name "code")
-                ) @codeblock (#offset! @codeblock 0 0 1 0))
+                )
+                (ranged_verbatim_tag
+                    name: (tag_name) @_name
+                    (#eq? @_name "code")
+                )] @codeblock (#offset! @codeblock 0 0 1 0))
 
                 (quote1_prefix) @quote
             ]]

--- a/lua/headlines/init.lua
+++ b/lua/headlines/init.lua
@@ -95,10 +95,14 @@ M.config = {
                 (weak_paragraph_delimiter) @dash
                 (strong_paragraph_delimiter) @doubledash
 
-                ((ranged_verbatim_tag
+                ([(ranged_tag
                     name: (tag_name) @_name
                     (#eq? @_name "code")
-                ) @codeblock (#offset! @codeblock 0 0 1 0))
+                )
+                (ranged_verbatim_tag
+                    name: (tag_name) @_name
+                    (#eq? @_name "code")
+                )] @codeblock (#offset! @codeblock 0 0 1 0))
 
                 (quote1_prefix) @quote
             ]]

--- a/lua/headlines/init.lua
+++ b/lua/headlines/init.lua
@@ -95,7 +95,7 @@ M.config = {
                 (weak_paragraph_delimiter) @dash
                 (strong_paragraph_delimiter) @doubledash
 
-                ((ranged_tag
+                ((ranged_verbatim_tag
                     name: (tag_name) @_name
                     (#eq? @_name "code")
                 ) @codeblock (#offset! @codeblock 0 0 1 0))


### PR DESCRIPTION
Not sure why Norg does this, but it supports two types of verbatim block syntaxes:
```norg
|code
style 1
|end

@code
style 2
@end
```
I guess the latter is ment for embedding code, which I assume headlines.nvim is aiming for.

This PR add support for both.