### PR TITLE
feat: add support for bullets

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ require("headlines").setup {
             ]]
         ),
         headline_highlights = { "Headline" },
+        bullet_highlights = {
+            "@text.title.1.marker.markdown",
+            "@text.title.2.marker.markdown",
+            "@text.title.3.marker.markdown",
+            "@text.title.4.marker.markdown",
+            "@text.title.5.marker.markdown",
+            "@text.title.6.marker.markdown",
+        },
+        bullets = { "◉", "○", "✸", "✿" },
         codeblock_highlight = "CodeBlock",
         dash_highlight = "Dash",
         dash_string = "-",
@@ -128,6 +137,15 @@ require("headlines").setup {
         ),
         treesitter_language = "markdown",
         headline_highlights = { "Headline" },
+        bullet_highlights = {
+            "@text.title.1.marker.markdown",
+            "@text.title.2.marker.markdown",
+            "@text.title.3.marker.markdown",
+            "@text.title.4.marker.markdown",
+            "@text.title.5.marker.markdown",
+            "@text.title.6.marker.markdown",
+        },
+        bullets = { "◉", "○", "✸", "✿" },
         codeblock_highlight = "CodeBlock",
         dash_highlight = "Dash",
         dash_string = "-",
@@ -166,6 +184,15 @@ require("headlines").setup {
             ]]
         ),
         headline_highlights = { "Headline" },
+        bullet_highlights = {
+            "@neorg.headings.1.prefix",
+            "@neorg.headings.2.prefix",
+            "@neorg.headings.3.prefix",
+            "@neorg.headings.4.prefix",
+            "@neorg.headings.5.prefix",
+            "@neorg.headings.6.prefix",
+        },
+        bullets = { "◉", "○", "✸", "✿" },
         codeblock_highlight = "CodeBlock",
         dash_highlight = "Dash",
         dash_string = "-",
@@ -190,7 +217,7 @@ require("headlines").setup {
 
                 (block
                     name: (expr) @_name
-                    (#eq? @_name "SRC")
+                    (#match? @_name "(SRC|src)")
                 ) @codeblock
 
                 (paragraph . (expr) @quote
@@ -199,6 +226,17 @@ require("headlines").setup {
             ]]
         ),
         headline_highlights = { "Headline" },
+        bullet_highlights = {
+            "OrgTSHeadlineLevel1",
+            "OrgTSHeadlineLevel2",
+            "OrgTSHeadlineLevel3",
+            "OrgTSHeadlineLevel4",
+            "OrgTSHeadlineLevel5",
+            "OrgTSHeadlineLevel6",
+            "OrgTSHeadlineLevel7",
+            "OrgTSHeadlineLevel8",
+        },
+        bullets = { "◉", "○", "✸", "✿" },
         codeblock_highlight = "CodeBlock",
         dash_highlight = "Dash",
         dash_string = "-",

--- a/doc/headlines.txt
+++ b/doc/headlines.txt
@@ -113,9 +113,20 @@ Default config: >
 
                   (block_quote_marker) @quote
                   (block_quote (paragraph (inline (block_continuation) @quote)))
+                  (block_quote (paragraph (block_continuation) @quote))
+                  (block_quote (block_continuation) @quote)
               ]]
           ),
           headline_highlights = { "Headline" },
+          bullet_highlights = {
+              "@text.title.1.marker.markdown",
+              "@text.title.2.marker.markdown",
+              "@text.title.3.marker.markdown",
+              "@text.title.4.marker.markdown",
+              "@text.title.5.marker.markdown",
+              "@text.title.6.marker.markdown",
+          },
+          bullets = { "◉", "○", "✸", "✿" },
           codeblock_highlight = "CodeBlock",
           dash_highlight = "Dash",
           dash_string = "-",
@@ -144,10 +155,21 @@ Default config: >
 
                   (block_quote_marker) @quote
                   (block_quote (paragraph (inline (block_continuation) @quote)))
+                  (block_quote (paragraph (block_continuation) @quote))
+                  (block_quote (block_continuation) @quote)
               ]]
           ),
           treesitter_language = "markdown",
           headline_highlights = { "Headline" },
+          bullet_highlights = {
+              "@text.title.1.marker.markdown",
+              "@text.title.2.marker.markdown",
+              "@text.title.3.marker.markdown",
+              "@text.title.4.marker.markdown",
+              "@text.title.5.marker.markdown",
+              "@text.title.6.marker.markdown",
+          },
+          bullets = { "◉", "○", "✸", "✿" },
           codeblock_highlight = "CodeBlock",
           dash_highlight = "Dash",
           dash_string = "-",
@@ -173,15 +195,28 @@ Default config: >
                   (weak_paragraph_delimiter) @dash
                   (strong_paragraph_delimiter) @doubledash
 
-                  ((ranged_tag
+                  ([(ranged_tag
                       name: (tag_name) @_name
                       (#eq? @_name "code")
-                  ) @codeblock (#offset! @codeblock 0 0 1 0))
-
+                  )
+                  (ranged_verbatim_tag
+                      name: (tag_name) @_name
+                      (#eq? @_name "code")
+                  )] @codeblock (#offset! @codeblock 0 0 1 0))
+  
                   (quote1_prefix) @quote
               ]]
           ),
           headline_highlights = { "Headline" },
+          bullet_highlights = {
+              "@neorg.headings.1.prefix",
+              "@neorg.headings.2.prefix",
+              "@neorg.headings.3.prefix",
+              "@neorg.headings.4.prefix",
+              "@neorg.headings.5.prefix",
+              "@neorg.headings.6.prefix",
+          },
+          bullets = { "◉", "○", "✸", "✿" },
           codeblock_highlight = "CodeBlock",
           dash_highlight = "Dash",
           dash_string = "-",
@@ -206,7 +241,7 @@ Default config: >
 
                   (block
                       name: (expr) @_name
-                      (#eq? @_name "SRC")
+                      (#match? @_name "(SRC|src)")
                   ) @codeblock
 
                   (paragraph . (expr) @quote
@@ -215,6 +250,17 @@ Default config: >
               ]]
           ),
           headline_highlights = { "Headline" },
+          bullet_highlights = {
+              "OrgTSHeadlineLevel1",
+              "OrgTSHeadlineLevel2",
+              "OrgTSHeadlineLevel3",
+              "OrgTSHeadlineLevel4",
+              "OrgTSHeadlineLevel5",
+              "OrgTSHeadlineLevel6",
+              "OrgTSHeadlineLevel7",
+              "OrgTSHeadlineLevel8",
+          },
+          bullets = { "◉", "○", "✸", "✿" },
           codeblock_highlight = "CodeBlock",
           dash_highlight = "Dash",
           dash_string = "-",
@@ -250,6 +296,20 @@ treesitter_language                            *headlines-treesitter_language*
 headline_highlights                            *headlines-headline_highlights*
 
     A list of |highlight| groups that are used to highlight the headline.
+    The level of the headline is used as the index of the list.
+
+------------------------------------------------------------------------------
+bullet_highlights                                *headlines-bullet_highlights*
+
+    A list of |highlight| groups that are used to highlight the headline
+    prefix/bullet.
+    The level of the headline is used as the index of the list.
+
+------------------------------------------------------------------------------
+bullets                                                    *headlines-bullets*
+
+    A list of strings that are displayed as the headline prefix/bullet.
+    Set it to an empty table to disable.
     The level of the headline is used as the index of the list.
 
 ------------------------------------------------------------------------------
@@ -311,7 +371,7 @@ quote_string                                            *headlines-quote_string*
 The MIT Licence
 http://www.opensource.org/licenses/mit-license.php
 
-Copyright (c) 2022 Lukas Reineke
+Copyright (c) 2024 Lukas Reineke
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lua/headlines/init.lua
+++ b/lua/headlines/init.lua
@@ -40,6 +40,15 @@ M.config = {
             ]]
         ),
         headline_highlights = { "Headline" },
+        bullet_highlights = {
+            "@text.title.1.marker.markdown",
+            "@text.title.2.marker.markdown",
+            "@text.title.3.marker.markdown",
+            "@text.title.4.marker.markdown",
+            "@text.title.5.marker.markdown",
+            "@text.title.6.marker.markdown",
+        },
+        bullets = { "◉", "○", "✸", "✿" },
         codeblock_highlight = "CodeBlock",
         dash_highlight = "Dash",
         dash_string = "-",
@@ -74,6 +83,15 @@ M.config = {
         ),
         treesitter_language = "markdown",
         headline_highlights = { "Headline" },
+        bullet_highlights = {
+            "@text.title.1.marker.markdown",
+            "@text.title.2.marker.markdown",
+            "@text.title.3.marker.markdown",
+            "@text.title.4.marker.markdown",
+            "@text.title.5.marker.markdown",
+            "@text.title.6.marker.markdown",
+        },
+        bullets = { "◉", "○", "✸", "✿" },
         codeblock_highlight = "CodeBlock",
         dash_highlight = "Dash",
         dash_string = "-",
@@ -112,6 +130,15 @@ M.config = {
             ]]
         ),
         headline_highlights = { "Headline" },
+        bullet_highlights = {
+            "@neorg.headings.1.prefix",
+            "@neorg.headings.2.prefix",
+            "@neorg.headings.3.prefix",
+            "@neorg.headings.4.prefix",
+            "@neorg.headings.5.prefix",
+            "@neorg.headings.6.prefix",
+        },
+        bullets = { "◉", "○", "✸", "✿" },
         codeblock_highlight = "CodeBlock",
         dash_highlight = "Dash",
         dash_string = "-",
@@ -145,6 +172,17 @@ M.config = {
             ]]
         ),
         headline_highlights = { "Headline" },
+        bullet_highlights = {
+            "OrgTSHeadlineLevel1",
+            "OrgTSHeadlineLevel2",
+            "OrgTSHeadlineLevel3",
+            "OrgTSHeadlineLevel4",
+            "OrgTSHeadlineLevel5",
+            "OrgTSHeadlineLevel6",
+            "OrgTSHeadlineLevel7",
+            "OrgTSHeadlineLevel8",
+        },
+        bullets = { "◉", "○", "✸", "✿" },
         codeblock_highlight = "CodeBlock",
         dash_highlight = "Dash",
         dash_string = "-",
@@ -238,10 +276,20 @@ M.refresh = function()
                     or vim.treesitter.get_node_text(node, bufnr)
                 local level = #vim.trim(get_text_function)
                 local hl_group = c.headline_highlights[math.min(level, #c.headline_highlights)]
+                local bullet_hl_group = c.bullet_highlights[math.min(level, #c.bullet_highlights)]
+
+                local virt_text = {}
+                if c.bullets and #c.bullets > 0 then
+                    local bullet = c.bullets[((level - 1) % #c.bullets) + 1]
+                    virt_text[1] = { string.rep(" ", level - 1) .. bullet, { hl_group, bullet_hl_group } }
+                end
+
                 nvim_buf_set_extmark(bufnr, M.namespace, start_row, 0, {
                     end_col = 0,
                     end_row = start_row + 1,
                     hl_group = hl_group,
+                    virt_text = virt_text,
+                    virt_text_pos = "overlay",
                     hl_eol = true,
                 })
 


### PR DESCRIPTION
⚠ BREAKING CHANGES
Bullets are turned on by default.
If you do not want them, set `:help headlines-bullets` to an empty table.