### PR TITLE
fix: ensure fat headlines are not shifted by conflicting extmarks

### DIFF
--- a/lua/headlines/init.lua
+++ b/lua/headlines/init.lua
@@ -303,6 +303,7 @@ M.refresh = function()
                             nvim_buf_set_extmark(bufnr, M.namespace, start_row - 1, 0, {
                                 virt_text = padding_above,
                                 virt_text_pos = "overlay",
+                                virt_text_win_col = 0,
                                 hl_mode = "combine",
                             })
                         else
@@ -319,6 +320,7 @@ M.refresh = function()
                         nvim_buf_set_extmark(bufnr, M.namespace, start_row + 1, 0, {
                             virt_text = padding_below,
                             virt_text_pos = "overlay",
+                            virt_text_win_col = 0,
                             hl_mode = "combine",
                         })
                         last_fat_headline = start_row + 1


### PR DESCRIPTION
Copied from the body of the commit message:

 > This commit makes `headlines.nvim` compatible with Nvim Orgmode's new Virtual Indent option added by https://github.com/nvim-orgmode/orgmode/pull/627.
 > 
 > This also will ensure any features like it in the future from other plugins do not interfere with the headlines later on.
 > 
 > In theory, extmark priorities would work here, but in pratice they do not. If this extmark is set *last* by a higher priority using only the virtual text, it can be arbitrarily shifted by other extmark content and the same occurs when the extmark set is of a lower priority. By specifying the window column to apply to, we bypass all the priorities shenanigans and directly set the correct position of the headline.

TL;DR:

Adds compat with virtual indents in Nvim Orgmode.

Before this change:
![image](https://github.com/lukas-reineke/headlines.nvim/assets/58627896/5229a912-f360-4055-9f84-6b0b85db0278)
Notice the weird indents on lines 2, 3, 5, 6, and 8. Those result from a conflicting extmark set by Nvim Orgmode trying to set virtual indentation.

After this change:
![image](https://github.com/lukas-reineke/headlines.nvim/assets/58627896/fa1122d8-3f40-4271-81d9-e121aa988df0)

Now `headlines.nvim` directly sets the window column to apply to instead of battling with other extmarks on virtext. (As a note, extmark priorities are *not* a solution in this case afaik, see the commit message body paragraph 3 for more details.)