### PR TITLE
doc: use new treesitter api for parsing queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Default config:
 ```lua
 require("headlines").setup {
     markdown = {
-        query = vim.treesitter.parse_query(
+        query = vim.treesitter.query.parse(
             "markdown",
             [[
                 (atx_heading [
@@ -113,7 +113,7 @@ require("headlines").setup {
         fat_headline_lower_string = "🬂",
     },
     rmd = {
-        query = vim.treesitter.parse_query(
+        query = vim.treesitter.query.parse(
             "markdown",
             [[
                 (atx_heading [
@@ -156,7 +156,7 @@ require("headlines").setup {
         fat_headline_lower_string = "🬂",
     },
     norg = {
-        query = vim.treesitter.parse_query(
+        query = vim.treesitter.query.parse(
             "norg",
             [[
                 [
@@ -205,7 +205,7 @@ require("headlines").setup {
         fat_headline_lower_string = "🬂",
     },
     org = {
-        query = vim.treesitter.parse_query(
+        query = vim.treesitter.query.parse(
             "org",
             [[
                 (headline (stars) @headline)
@@ -259,7 +259,7 @@ require("headlines").setup {
         headline_highlights = false,
     },
     yaml = {
-        query = vim.treesitter.parse_query(
+        query = vim.treesitter.query.parse(
             "yaml",
             [[
                 (

--- a/doc/headlines.txt
+++ b/doc/headlines.txt
@@ -95,7 +95,7 @@ Default config: >
 
   require("headlines").setup {
       markdown = {
-          query = vim.treesitter.parse_query(
+          query = vim.treesitter.query.parse(
               "markdown",
               [[
                   (atx_heading [
@@ -137,7 +137,7 @@ Default config: >
           fat_headline_lower_string = "🬂",
       },
       rmd = {
-          query = vim.treesitter.parse_query(
+          query = vim.treesitter.query.parse(
               "markdown",
               [[
                   (atx_heading [
@@ -180,7 +180,7 @@ Default config: >
           fat_headline_lower_string = "🬂",
       },
       norg = {
-          query = vim.treesitter.parse_query(
+          query = vim.treesitter.query.parse(
               "norg",
               [[
                   [
@@ -203,7 +203,7 @@ Default config: >
                       name: (tag_name) @_name
                       (#eq? @_name "code")
                   )] @codeblock (#offset! @codeblock 0 0 1 0))
-  
+
                   (quote1_prefix) @quote
               ]]
           ),
@@ -229,7 +229,7 @@ Default config: >
           fat_headline_lower_string = "🬂",
       },
       org = {
-          query = vim.treesitter.parse_query(
+          query = vim.treesitter.query.parse(
               "org",
               [[
                   (headline (stars) @headline)

--- a/lua/headlines/init.lua
+++ b/lua/headlines/init.lua
@@ -6,7 +6,7 @@ local q = require "vim.treesitter.query"
 local use_legacy_query = vim.fn.has "nvim-0.9.0" ~= 1
 
 local parse_query_save = function(language, query)
-    -- vim.treesitter.query.parse_query() is deprecated, use vim.treesitter.query.parse() instead
+    -- vim.treesitter.parse_query() is deprecated, use vim.treesitter.query.parse() instead
     local ok, parsed_query =
         pcall(use_legacy_query and vim.treesitter.query.parse_query or vim.treesitter.query.parse, language, query)
     if not ok then


### PR DESCRIPTION
The code is already using the new function. Only the documentation was referencing the old API.
`vim.treesitter.parse_query` -> `vim.treesitter.query.parse`