### PR TITLE
feat: allow fat_headlines to be a function

### DIFF
--- a/doc/headlines.txt
+++ b/doc/headlines.txt
@@ -315,7 +315,8 @@ bullets                                                    *headlines-bullets*
 ------------------------------------------------------------------------------
 fat_headlines                                        *headlines-fat_headlines*
 
-    Boolean to turn on fat headlines.
+    Specifies whether or not to use fat headlines.
+    Can be a boolean or a function returning a boolean.
 
 ------------------------------------------------------------------------------
 fat_headline_upper_string                *headlines-fat_headline_upper_string*

--- a/lua/headlines/init.lua
+++ b/lua/headlines/init.lua
@@ -293,7 +293,10 @@ M.refresh = function()
                     hl_eol = true,
                 })
 
-                if c.fat_headlines then
+                local use_fat_headlines = (type(c.fat_headlines) == "boolean") and c.fat_headlines or
+                                          ((type(c.fat_headlines) == "function") and c.fat_headlines() or false)
+
+                if use_fat_headlines then
                     local reverse_hl_group = M.make_reverse_highlight(hl_group)
 
                     local padding_above = { { c.fat_headline_upper_string:rep(width), reverse_hl_group } }


### PR DESCRIPTION
While using Neorg toc (Table of Contents) I found the fat_headlines taking up far to much space.
However, I really like the way they look outside of the toc buffer.
This can now be achieved by adding something like this to your headlines.nvim config:

``` lua
require('headlines').setup({
    norg = {
        fat_headlines = function()
            -- Return a true if not toc file
        end,
    },
})
```