### PR TITLE
Use a more commonly supported character for `fat_headline_lower_string`

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ require("headlines").setup {
         quote_highlight = "Quote",
         quote_string = "┃",
         fat_headlines = true,
-        fat_headline_upper_string = "▃",
+        fat_headline_upper_string = "▄",
         fat_headline_lower_string = "▀",
     },
     rmd = {
@@ -152,7 +152,7 @@ require("headlines").setup {
         quote_highlight = "Quote",
         quote_string = "┃",
         fat_headlines = true,
-        fat_headline_upper_string = "▃",
+        fat_headline_upper_string = "▄",
         fat_headline_lower_string = "▀",
     },
     norg = {
@@ -201,7 +201,7 @@ require("headlines").setup {
         quote_highlight = "Quote",
         quote_string = "┃",
         fat_headlines = true,
-        fat_headline_upper_string = "▃",
+        fat_headline_upper_string = "▄",
         fat_headline_lower_string = "▀",
     },
     org = {
@@ -243,7 +243,7 @@ require("headlines").setup {
         quote_highlight = "Quote",
         quote_string = "┃",
         fat_headlines = true,
-        fat_headline_upper_string = "▃",
+        fat_headline_upper_string = "▄",
         fat_headline_lower_string = "▀",
     },
 }

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ require("headlines").setup {
         quote_string = "┃",
         fat_headlines = true,
         fat_headline_upper_string = "▃",
-        fat_headline_lower_string = "🬂",
+        fat_headline_lower_string = "▀",
     },
     rmd = {
         query = vim.treesitter.parse_query(
@@ -153,7 +153,7 @@ require("headlines").setup {
         quote_string = "┃",
         fat_headlines = true,
         fat_headline_upper_string = "▃",
-        fat_headline_lower_string = "🬂",
+        fat_headline_lower_string = "▀",
     },
     norg = {
         query = vim.treesitter.parse_query(
@@ -202,7 +202,7 @@ require("headlines").setup {
         quote_string = "┃",
         fat_headlines = true,
         fat_headline_upper_string = "▃",
-        fat_headline_lower_string = "🬂",
+        fat_headline_lower_string = "▀",
     },
     org = {
         query = vim.treesitter.parse_query(
@@ -244,7 +244,7 @@ require("headlines").setup {
         quote_string = "┃",
         fat_headlines = true,
         fat_headline_upper_string = "▃",
-        fat_headline_lower_string = "🬂",
+        fat_headline_lower_string = "▀",
     },
 }
 ```

--- a/doc/headlines.txt
+++ b/doc/headlines.txt
@@ -134,7 +134,7 @@ Default config: >
           quote_string = "┃",
           fat_headlines = true,
           fat_headline_upper_string = "▃",
-          fat_headline_lower_string = "🬂",
+          fat_headline_lower_string = "▀",
       },
       rmd = {
           query = vim.treesitter.parse_query(
@@ -177,7 +177,7 @@ Default config: >
           quote_string = "┃",
           fat_headlines = true,
           fat_headline_upper_string = "▃",
-          fat_headline_lower_string = "🬂",
+          fat_headline_lower_string = "▀",
       },
       norg = {
           query = vim.treesitter.parse_query(
@@ -226,7 +226,7 @@ Default config: >
           quote_string = "┃",
           fat_headlines = true,
           fat_headline_upper_string = "▃",
-          fat_headline_lower_string = "🬂",
+          fat_headline_lower_string = "▀",
       },
       org = {
           query = vim.treesitter.parse_query(
@@ -268,7 +268,7 @@ Default config: >
           quote_string = "┃",
           fat_headlines = true,
           fat_headline_upper_string = "▃",
-          fat_headline_lower_string = "🬂",
+          fat_headline_lower_string = "▀",
       },
   }
 

--- a/doc/headlines.txt
+++ b/doc/headlines.txt
@@ -133,7 +133,7 @@ Default config: >
           quote_highlight = "Quote",
           quote_string = "┃",
           fat_headlines = true,
-          fat_headline_upper_string = "▃",
+          fat_headline_upper_string = "▄",
           fat_headline_lower_string = "▀",
       },
       rmd = {
@@ -176,7 +176,7 @@ Default config: >
           quote_highlight = "Quote",
           quote_string = "┃",
           fat_headlines = true,
-          fat_headline_upper_string = "▃",
+          fat_headline_upper_string = "▄",
           fat_headline_lower_string = "▀",
       },
       norg = {
@@ -225,7 +225,7 @@ Default config: >
           quote_highlight = "Quote",
           quote_string = "┃",
           fat_headlines = true,
-          fat_headline_upper_string = "▃",
+          fat_headline_upper_string = "▄",
           fat_headline_lower_string = "▀",
       },
       org = {
@@ -267,7 +267,7 @@ Default config: >
           quote_highlight = "Quote",
           quote_string = "┃",
           fat_headlines = true,
-          fat_headline_upper_string = "▃",
+          fat_headline_upper_string = "▄",
           fat_headline_lower_string = "▀",
       },
   }

--- a/lua/headlines/init.lua
+++ b/lua/headlines/init.lua
@@ -56,7 +56,7 @@ M.config = {
         quote_string = "┃",
         fat_headlines = true,
         fat_headline_upper_string = "▃",
-        fat_headline_lower_string = "🬂",
+        fat_headline_lower_string = "▀",
     },
     rmd = {
         query = parse_query_save(
@@ -99,7 +99,7 @@ M.config = {
         quote_string = "┃",
         fat_headlines = true,
         fat_headline_upper_string = "▃",
-        fat_headline_lower_string = "🬂",
+        fat_headline_lower_string = "▀",
     },
     norg = {
         query = parse_query_save(
@@ -148,7 +148,7 @@ M.config = {
         quote_string = "┃",
         fat_headlines = true,
         fat_headline_upper_string = "▃",
-        fat_headline_lower_string = "🬂",
+        fat_headline_lower_string = "▀",
     },
     org = {
         query = parse_query_save(
@@ -190,7 +190,7 @@ M.config = {
         quote_string = "┃",
         fat_headlines = true,
         fat_headline_upper_string = "▃",
-        fat_headline_lower_string = "🬂",
+        fat_headline_lower_string = "▀",
     },
 }
 

--- a/lua/headlines/init.lua
+++ b/lua/headlines/init.lua
@@ -55,7 +55,7 @@ M.config = {
         quote_highlight = "Quote",
         quote_string = "┃",
         fat_headlines = true,
-        fat_headline_upper_string = "▃",
+        fat_headline_upper_string = "▄",
         fat_headline_lower_string = "▀",
     },
     rmd = {
@@ -98,7 +98,7 @@ M.config = {
         quote_highlight = "Quote",
         quote_string = "┃",
         fat_headlines = true,
-        fat_headline_upper_string = "▃",
+        fat_headline_upper_string = "▄",
         fat_headline_lower_string = "▀",
     },
     norg = {
@@ -147,7 +147,7 @@ M.config = {
         quote_highlight = "Quote",
         quote_string = "┃",
         fat_headlines = true,
-        fat_headline_upper_string = "▃",
+        fat_headline_upper_string = "▄",
         fat_headline_lower_string = "▀",
     },
     org = {
@@ -189,7 +189,7 @@ M.config = {
         quote_highlight = "Quote",
         quote_string = "┃",
         fat_headlines = true,
-        fat_headline_upper_string = "▃",
+        fat_headline_upper_string = "▄",
         fat_headline_lower_string = "▀",
     },
 }


### PR DESCRIPTION
Update: this PR now uses matching "Upper Half Block" and "Lower Half Block" to generate vertically centered half headlines.

 ## What

This PR replaces the character `🬂` ([Block Sextant-12 (U+1FB02)](https://unicodeplus.com/U+1FB02)) with `▀` ([Upper Half Block (U+2580)](https://unicodeplus.com/U+2580)) to be used for the `fat_headline_lower_string` configuration everywhere.

 ## Why

The _Block Sextant-12_ character is part of a Unicode block named [_Symbols for **Legacy** Computing_](https://en.wikipedia.org/wiki/Symbols_for_Legacy_Computing).
(Emphasis on "legacy" mine. 😬)

This character seems to not be supported by a lot of fonts and many terminals, as well as other applications (one might even see a "missing character" square while browsing this PR and links I provided).

I have for example confirmed that it would not work with the following:
- Terminal apps:
  - macOS' Terminal.app
  - iTerm2
  - Alacritty with `builtin_box_drawing` set to `false`
- Fonts:
  - Monaco
  - MonaspiceNe Nerd Font
  - SFMono Nerd Font
  - Fira Code Nerd Font

_Upper Half Block_ is slightly thicker than _Block Sextant-12_, but it also appears to be more widely supported across terminals and fonts.

I think a default configuration that will work in most environments would provide a better user experience, and would likely prevent many developers from spending hours diving into the unknown territories of font rendering, Unicode blocks, NeoVim LUA configuration, etc.

 ## How

A simple script that replaces all instances of the _Block Sextant-12_ character in the repository:

```sh
 ag -l \U0001fb02 | xargs -n1 sed -i '' -e "s/\U0001fb02/▀/"
```

 ## Anything else?

 ### Alternative

An alternative to _Upper Half Block_ would be the thinner `▔` ([Upper One Eighth Block (U+2594)](https://unicodeplus.com/U+2594)).

 ### Matching "lower" and "upper"

If it is important for the width of the fat headline top and bottom padding be identical, then we could also change `fat_headline_upper_string` to use a character of the same width.
Respectively, in order of appearance above:
- `▄` ([Lower Half Block (U+2584)](https://unicodeplus.com/U+2584))
- `▁` ([Lower One Eighth Block (U+2581)](https://unicodeplus.com/U+2581))


## Screenshots

Using the `evening` colorscheme, iTerm2 with MonaspiceNe Nerd Font.

| What | Screenshot |
|--------|--------|
| Before | <img width="298" alt="image" src="https://github.com/lukas-reineke/headlines.nvim/assets/816901/57db641b-6043-4e39-be3d-fdfa021d8b1c"> |
| This PR | <img width="298" alt="image" src="https://github.com/lukas-reineke/headlines.nvim/assets/816901/c3873b6d-4bcc-46d3-8d45-023491e7617f"> |
| Alt:<br>upper one eighth | <img width="298" alt="image" src="https://github.com/lukas-reineke/headlines.nvim/assets/816901/aedd5bec-46fd-4d45-bf9c-1732c07625bb"> |
| Alt:<br>matching half blocks | <img width="298" alt="image" src="https://github.com/lukas-reineke/headlines.nvim/assets/816901/3027957c-c162-4b48-b400-c6ea55e200e4"> |
| Alt:<br>matching 1/8 blocks | <img width="298" alt="image" src="https://github.com/lukas-reineke/headlines.nvim/assets/816901/f19fcc75-658a-4fc7-acbd-49ee52a2cd37"> |