### PR TITLE
Improve support for variable bullet lengths

### DIFF
--- a/lua/headlines/init.lua
+++ b/lua/headlines/init.lua
@@ -281,7 +281,7 @@ M.refresh = function()
                 local virt_text = {}
                 if c.bullets and #c.bullets > 0 then
                     local bullet = c.bullets[((level - 1) % #c.bullets) + 1]
-                    virt_text[1] = { string.rep(" ", level - 1) .. bullet, { hl_group, bullet_hl_group } }
+                    virt_text[1] = { string.rep(" ", level - vim.fn.strwidth(bullet)) .. bullet, { hl_group, bullet_hl_group } }
                 end
 
                 nvim_buf_set_extmark(bufnr, M.namespace, start_row, 0, {


### PR DESCRIPTION
I personally like to still have the number of bullets equal to the heading level to simpler overview on what level I am at. Before this PR, it was already possible to set more than one character for a bullet, but the virtual text was then misaligned. This PR allows to define several characters for the bullets ensuring they are correctly aligned as long as the character count is less or equal to the heading level on which they will be applied. Thus, configurations such as the following become possible and are properly aligned: https://github.com/f4z3r/nix/blob/3dfe0f2a28920f1598662c948b846651f551c4f3/home/apps/nvim/plugin/headlines.lua#L4

Existing configurations are not affected by the change.