### PR TITLE
fix: support `Query:iter_matches` changes in upstream neovim

### DIFF
--- a/lua/headlines/init.lua
+++ b/lua/headlines/init.lua
@@ -286,7 +286,8 @@ M.refresh = function()
                 local virt_text = {}
                 if c.bullets and #c.bullets > 0 then
                     local bullet = c.bullets[((level - 1) % #c.bullets) + 1]
-                    virt_text[1] = { string.rep(" ", level - vim.fn.strwidth(bullet)) .. bullet, { hl_group, bullet_hl_group } }
+                    virt_text[1] =
+                        { string.rep(" ", level - vim.fn.strwidth(bullet)) .. bullet, { hl_group, bullet_hl_group } }
                 end
 
                 nvim_buf_set_extmark(bufnr, M.namespace, start_row, 0, {

--- a/lua/headlines/init.lua
+++ b/lua/headlines/init.lua
@@ -4,6 +4,7 @@ M.namespace = vim.api.nvim_create_namespace "headlines_namespace"
 local q = require "vim.treesitter.query"
 
 local use_legacy_query = vim.fn.has "nvim-0.9.0" ~= 1
+local has_quantified_captures = vim.fn.has "nvim-0.11.0" == 1
 
 local parse_query_save = function(language, query)
     -- vim.treesitter.query.parse_query() is deprecated, use vim.treesitter.query.parse() instead
@@ -266,6 +267,10 @@ M.refresh = function()
 
     for _, match, metadata in c.query:iter_matches(root, bufnr) do
         for id, node in pairs(match) do
+            if has_quantified_captures then
+                node = node[#node]
+            end
+
             local capture = c.query.captures[id]
             local start_row, start_column, end_row, end_column =
                 unpack(vim.tbl_extend("force", { node:range() }, (metadata[id] or {}).range or {}))


### PR DESCRIPTION
Copied from the body of the commit:

> Neovim's `Query:iter_matches` function now returns a list of Nodes for each match in nightly. Previously the `iter_matches` function only returned the *last* node. To get that previous behavior we just pull the last node out of the returned list of nodes.
> 
> According to `:h news.txt`, `Query:iter_matches` added a backwards compatibility option (`all=false`), but the intent is to remove it in a future release — thus it's better to rip the band-aid off now instead of fighting this again later on.
> 
> See https://github.com/neovim/neovim/commit/6913c5e1d975a11262d08b3339d50b579e6b6bb8.


TL;DR:

Neovim upstream recently changed the return from `Query:iter_matches` and this adds a simple shim to support it for current nightly users. It should have the exact same behavior as what was previously used AFAIK.
